### PR TITLE
feat: use hair space U+200A and constant it

### DIFF
--- a/libs/pangu/src/main/java/ws/vinta/pangu/Pangu.kt
+++ b/libs/pangu/src/main/java/ws/vinta/pangu/Pangu.kt
@@ -24,6 +24,12 @@ import java.util.regex.Pattern
  */
 class Pangu {
     companion object {
+
+        /**
+         * The space character.
+         */
+        private const val SPACE = " "
+
         /*
          * Some capturing group patterns for convenience.
          *
@@ -138,37 +144,37 @@ class Pangu {
 
         // CJK and quotes
         val cqMatcher = CJK_QUOTE.matcher(text)
-        text = cqMatcher.replaceAll("$1 $2")
+        text = cqMatcher.replaceAll("$1$SPACE$2")
         val qcMatcher = QUOTE_CJK.matcher(text)
-        text = qcMatcher.replaceAll("$1 $2")
+        text = qcMatcher.replaceAll("$1$SPACE$2")
         val fixQuoteMatcher = FIX_QUOTE.matcher(text)
         text = fixQuoteMatcher.replaceAll("$1$3$5")
 
         // CJK and brackets
         val oldText = text
         val cbcMatcher = CJK_BRACKET_CJK.matcher(text)
-        val newText = cbcMatcher.replaceAll("$1 $2 $4")
+        val newText = cbcMatcher.replaceAll("$1$SPACE$2$SPACE$4")
         text = newText
         if (oldText == newText) {
             val cbMatcher = CJK_BRACKET.matcher(text)
-            text = cbMatcher.replaceAll("$1 $2")
+            text = cbMatcher.replaceAll("$1$SPACE$2")
             val bcMatcher = BRACKET_CJK.matcher(text)
-            text = bcMatcher.replaceAll("$1 $2")
+            text = bcMatcher.replaceAll("$1$SPACE$2")
         }
         val fixBracketMatcher = FIX_BRACKET.matcher(text)
         text = fixBracketMatcher.replaceAll("$1$3$5")
 
         // CJK and hash
         val chMatcher = CJK_HASH.matcher(text)
-        text = chMatcher.replaceAll("$1 $2")
+        text = chMatcher.replaceAll("$1$SPACE$2")
         val hcMatcher = HASH_CJK.matcher(text)
-        text = hcMatcher.replaceAll("$1 $3")
+        text = hcMatcher.replaceAll("$1$SPACE$3")
 
         // CJK and ANS
         val caMatcher = CJK_ANS.matcher(text)
-        text = caMatcher.replaceAll("$1 $2")
+        text = caMatcher.replaceAll("$1$SPACE$2")
         val acMatcher = ANS_CJK.matcher(text)
-        text = acMatcher.replaceAll("$1 $2")
+        text = acMatcher.replaceAll("$1$SPACE$2")
 
         return text
     }


### PR DESCRIPTION
# Use hair space to bring better visual effects for CJK

See https://www.compart.com/en/unicode/U+200A

## Description

Hair Space
![image](https://github.com/user-attachments/assets/f28eb1f4-e000-4fcf-aa65-c51b857d2d32)

Normal Space
![image](https://github.com/user-attachments/assets/dcb5fcf6-8515-4bf5-9b9f-66f861105e87)

## Issues Fixed or Closed by This PR

Not needed.

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] My code follows the code style of this project
- [x] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
