### PR TITLE
refactor: replace to thin space U+2009

### DIFF
--- a/libs/pangu/src/main/java/ws/vinta/pangu/Pangu.kt
+++ b/libs/pangu/src/main/java/ws/vinta/pangu/Pangu.kt
@@ -28,7 +28,7 @@ class Pangu {
         /**
          * The space character.
          */
-        private const val SPACE = " "
+        private const val SPACE = " "
 
         /*
          * Some capturing group patterns for convenience.


### PR DESCRIPTION
Same as #51

间距大小对 Telegram 字体渲染不合适，使用 U+2009 增大间距