### PR TITLE
feat(dialogs): retain read chats in unread folder for configurable duration

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -1305,7 +1305,7 @@ public class MessagesController extends BaseController implements NotificationCe
                 return false;
             }
             if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0 && messagesController.getDialogUnreadCount(d) == 0 && !d.unread_mark && d.unread_mentions_count == 0) {
-                if (!UnreadDialogRetention.shouldRetain(dialogId)) {
+                if (!UnreadDialogRetention.shouldRetain(accountInstance.getCurrentAccount(), dialogId)) {
                     return false;
                 }
             }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -136,6 +136,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import xyz.nextalone.gen.Config;
+import xyz.nextalone.nnngram.utils.UnreadDialogRetention;
 
 public class MessagesController extends BaseController implements NotificationCenter.NotificationCenterDelegate {
 
@@ -1300,9 +1301,13 @@ public class MessagesController extends BaseController implements NotificationCe
             ContactsController contactsController = accountInstance.getContactsController();
             boolean skip = false;
 
-            if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_MUTED) != 0 && messagesController.isDialogMuted(d.id, 0) && d.unread_mentions_count == 0 ||
-                    (flags & DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0 && messagesController.getDialogUnreadCount(d) == 0 && !d.unread_mark && d.unread_mentions_count == 0) {
+            if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_MUTED) != 0 && messagesController.isDialogMuted(d.id, 0) && d.unread_mentions_count == 0) {
                 return false;
+            }
+            if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0 && messagesController.getDialogUnreadCount(d) == 0 && !d.unread_mark && d.unread_mentions_count == 0) {
+                if (!UnreadDialogRetention.shouldRetain(dialogId)) {
+                    return false;
+                }
             }
             if (dialogId > 0) {
                 TLRPC.User user = messagesController.getUser(dialogId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -286,6 +286,7 @@ import xyz.nextalone.nnngram.ui.SendOptionsMenuLayout;
 import xyz.nextalone.nnngram.utils.APKUtils;
 import xyz.nextalone.nnngram.utils.Defines;
 import xyz.nextalone.nnngram.utils.PrivacyUtils;
+import xyz.nextalone.nnngram.utils.UnreadDialogRetention;
 import xyz.nextalone.nnngram.utils.UpdateUtils;
 
 import me.vkryl.android.animator.BoolAnimator;
@@ -8044,6 +8045,15 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 }
             } else {
                 slowedReloadAfterDialogClick = true;
+                if (UnreadDialogRetention.isEnabled() && viewPages != null && viewPages.length > 0) {
+                    MessagesController.DialogFilter currentFilter = null;
+                    if (viewPages[0].dialogsType == 7 || viewPages[0].dialogsType == 8) {
+                        currentFilter = getMessagesController().selectedDialogFilter[viewPages[0].dialogsType == 8 ? 1 : 0];
+                    }
+                    if (currentFilter != null && (currentFilter.flags & MessagesController.DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0) {
+                        UnreadDialogRetention.onDialogOpened(dialogId);
+                    }
+                }
                 if (getMessagesController().checkCanOpenChat(args, DialogsActivity.this)) {
                     TLRPC.Chat chat = getMessagesController().getChat(-dialogId);
                     TLRPC.Dialog dialog = getMessagesController().getDialog(dialogId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -8051,7 +8051,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                         currentFilter = getMessagesController().selectedDialogFilter[viewPages[0].dialogsType == 8 ? 1 : 0];
                     }
                     if (currentFilter != null && (currentFilter.flags & MessagesController.DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0) {
-                        UnreadDialogRetention.onDialogOpened(dialogId);
+                        UnreadDialogRetention.onDialogOpened(currentAccount, dialogId);
                     }
                 }
                 if (getMessagesController().checkCanOpenChat(args, DialogsActivity.this)) {

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
@@ -68,6 +68,7 @@ import xyz.nextalone.nnngram.helpers.TranslateHelper.ProviderType;
 import xyz.nextalone.nnngram.translate.providers.DeepLTranslator;
 import xyz.nextalone.nnngram.ui.PopupBuilder;
 import xyz.nextalone.nnngram.utils.Defines;
+import xyz.nextalone.nnngram.utils.UnreadDialogRetention;
 
 @SuppressLint("NotifyDataSetChanged")
 public class GeneralSettingActivity extends BaseActivity {
@@ -289,6 +290,7 @@ public class GeneralSettingActivity extends BaseActivity {
             }
             PopupBuilder.show(arrayList, LocaleController.getString(R.string.unreadDialogRetention), currentIndex, getParentActivity(), view, i -> {
                 Config.setUnreadDialogRetention(types.get(i));
+                UnreadDialogRetention.clearAndReload();
                 listAdapter.notifyItemChanged(unreadDialogRetentionRow, PARTIAL);
             });
         } else if (position == autoDisableBuiltInProxyRow) {

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
@@ -116,6 +116,7 @@ public class GeneralSettingActivity extends BaseActivity {
     private int keepContactNicknameRow;
     private int ignoreUserSpecifiedReplyColorRow;
     private int ignoreFolderUnreadCountRow;
+    private int unreadDialogRetentionRow;
     private int hideProxyEntryInTitleRow;
     private int showProxyEntryInDrawerRow;
     private int hideFilterMuteAllRow;
@@ -271,6 +272,25 @@ public class GeneralSettingActivity extends BaseActivity {
             if (view instanceof TextCheckCell) {
                 ((TextCheckCell) view).setChecked(Config.ignoreFolderUnreadCount);
             }
+        } else if (position == unreadDialogRetentionRow) {
+            ArrayList<String> arrayList = new ArrayList<>();
+            ArrayList<Integer> types = new ArrayList<>();
+            arrayList.add(LocaleController.getString(R.string.unreadDialogRetentionOff));
+            types.add(Defines.unreadDialogRetentionOff);
+            arrayList.add(LocaleController.getString(R.string.unreadDialogRetention5Min));
+            types.add(Defines.unreadDialogRetention5Min);
+            arrayList.add(LocaleController.getString(R.string.unreadDialogRetention30Min));
+            types.add(Defines.unreadDialogRetention30Min);
+            arrayList.add(LocaleController.getString(R.string.unreadDialogRetention2Hour));
+            types.add(Defines.unreadDialogRetention2Hour);
+            int currentIndex = types.indexOf(Config.getUnreadDialogRetention());
+            if (currentIndex < 0) {
+                currentIndex = 0;
+            }
+            PopupBuilder.show(arrayList, LocaleController.getString(R.string.unreadDialogRetention), currentIndex, getParentActivity(), view, i -> {
+                Config.setUnreadDialogRetention(types.get(i));
+                listAdapter.notifyItemChanged(unreadDialogRetentionRow, PARTIAL);
+            });
         } else if (position == autoDisableBuiltInProxyRow) {
             Config.toggleAutoDisableBuiltInProxy();
             if (view instanceof TextCheckCell) {
@@ -523,6 +543,7 @@ public class GeneralSettingActivity extends BaseActivity {
         ignoreUserSpecifiedReplyColorRow = addRow("ignoreUserSpecifiedReplyColor");
         tabsTitleTypeRow = addRow("tabsTitleType");
         ignoreFolderUnreadCountRow = addRow("ignoreFolderUnreadCount");
+        unreadDialogRetentionRow = addRow("unreadDialogRetention");
         hideFilterMuteAllRow = addRow("hideFilterMuteAll");
         hideProxyEntryInTitleRow = addRow();
         showProxyEntryInDrawerRow = addRow("showProxyEntryInDrawer");
@@ -582,6 +603,14 @@ public class GeneralSettingActivity extends BaseActivity {
                             default -> LocaleController.getString("TabTitleTypeMix", R.string.TabTitleTypeMix);
                         };
                         textCell.setTextAndValue(LocaleController.getString("TabTitleType", R.string.TabTitleType), value, payload, false);
+                    } else if (position == unreadDialogRetentionRow) {
+                        String value = switch (Config.getUnreadDialogRetention()) {
+                            case Defines.unreadDialogRetention5Min -> LocaleController.getString(R.string.unreadDialogRetention5Min);
+                            case Defines.unreadDialogRetention30Min -> LocaleController.getString(R.string.unreadDialogRetention30Min);
+                            case Defines.unreadDialogRetention2Hour -> LocaleController.getString(R.string.unreadDialogRetention2Hour);
+                            default -> LocaleController.getString(R.string.unreadDialogRetentionOff);
+                        };
+                        textCell.setTextAndValue(LocaleController.getString(R.string.unreadDialogRetention), value, payload, true);
                     } else if (position == overrideDevicePerformanceRow) {
                         String value = switch (Config.getDevicePerformance()) {
                             case Defines.devicePerformanceLow -> LocaleController.getString("DevicePerformanceLow", R.string.DevicePerformanceLow);
@@ -864,7 +893,7 @@ public class GeneralSettingActivity extends BaseActivity {
             } else if (position == tabsTitleTypeRow || position == translationProviderRow || position == deepLFormalityRow || position == translationTargetRow ||
                 position == translatorTypeRow || position == doNotTranslateRow || position == overrideDevicePerformanceRow || position == customTitleRow ||
                 position == deepLxApiRow || position == editTextTranslationTargetRow ||
-                position == llmConfigRow) {
+                position == llmConfigRow || position == unreadDialogRetentionRow) {
                 return 2;
             } else if (position == drawerRow || position == generalRow || position == translatorRow || position == devicesRow || position == storiesRow || position == llmSettingsRow) {
                 return 4;

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/Defines.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/Defines.kt
@@ -259,6 +259,20 @@ object Defines {
     @BooleanConfig const val mergeMessage = "mergeMessage"
     @BooleanConfig const val filterZalgo = "filterZalgo"
     @BooleanConfig const val ignoreFolderUnreadCount = "ignoreFolderUnreadCount"
+
+    /**
+     * Retention duration (in seconds) for read dialogs that should still be displayed
+     * inside the "Unread" dialog filter / folder.
+     * 0 = off (default, original behavior: read dialog disappears immediately)
+     * 300 = 5 minutes
+     * 1800 = 30 minutes
+     * 7200 = 2 hours
+     */
+    @IntConfig(0) const val unreadDialogRetention = "unreadDialogRetention"
+    const val unreadDialogRetentionOff = 0
+    const val unreadDialogRetention5Min = 300
+    const val unreadDialogRetention30Min = 1800
+    const val unreadDialogRetention2Hour = 7200
     @BooleanConfig const val ignoreChatStrict = "ignoreChatStrict"
     @StringConfig("Nnngram") const val customTitle = "customTitle"
     @StringConfig("") const val textStyleSettings = "textStyleSettings"

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -71,7 +71,7 @@ object UnreadDialogRetention {
     }
 
     private fun mapFor(account: Int): ConcurrentHashMap<Long, Long> =
-        expireAtByAccount.getOrPut(account) { ConcurrentHashMap() }
+        expireAtByAccount.computeIfAbsent(account) { ConcurrentHashMap() }
 
     private fun scheduleNextExpiration() {
         AndroidUtilities.runOnUIThread {

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 object UnreadDialogRetention {
 
-    private val expireAtById = ConcurrentHashMap<Long, Long>()
+    private val expireAtByAccount = ConcurrentHashMap<Int, ConcurrentHashMap<Long, Long>>()
 
     private var pendingExpireRunnable: Runnable? = null
 
@@ -37,44 +37,56 @@ object UnreadDialogRetention {
     fun getRetentionMillis(): Long = Config.getUnreadDialogRetention() * 1000L
 
     @JvmStatic
-    fun onDialogOpened(dialogId: Long) {
+    fun onDialogOpened(account: Int, dialogId: Long) {
         val retentionMillis = getRetentionMillis()
         if (retentionMillis <= 0) {
             return
         }
-        expireAtById[dialogId] = System.currentTimeMillis() + retentionMillis
+        mapFor(account)[dialogId] = System.currentTimeMillis() + retentionMillis
         scheduleNextExpiration()
     }
 
     @JvmStatic
-    fun shouldRetain(dialogId: Long): Boolean {
+    fun shouldRetain(account: Int, dialogId: Long): Boolean {
         if (!isEnabled()) {
             return false
         }
-        val expireAt = expireAtById[dialogId] ?: return false
+        val map = expireAtByAccount[account] ?: return false
+        val expireAt = map[dialogId] ?: return false
         if (System.currentTimeMillis() >= expireAt) {
-            expireAtById.remove(dialogId)
+            map.remove(dialogId)
             return false
         }
         return true
     }
 
     @JvmStatic
-    fun clear() {
-        expireAtById.clear()
+    fun clearAndReload() {
+        val accounts = expireAtByAccount.keys.toList()
+        expireAtByAccount.clear()
         cancelPending()
+        for (account in accounts) {
+            notifyDialogsReload(account)
+        }
     }
+
+    private fun mapFor(account: Int): ConcurrentHashMap<Long, Long> =
+        expireAtByAccount.getOrPut(account) { ConcurrentHashMap() }
 
     private fun scheduleNextExpiration() {
         AndroidUtilities.runOnUIThread {
             cancelPending()
             val now = System.currentTimeMillis()
             var earliest = Long.MAX_VALUE
-            for ((id, expireAt) in expireAtById) {
-                if (expireAt <= now) {
-                    expireAtById.remove(id)
-                } else if (expireAt < earliest) {
-                    earliest = expireAt
+            for ((_, map) in expireAtByAccount) {
+                val it = map.entries.iterator()
+                while (it.hasNext()) {
+                    val entry = it.next()
+                    if (entry.value <= now) {
+                        it.remove()
+                    } else if (entry.value < earliest) {
+                        earliest = entry.value
+                    }
                 }
             }
             if (earliest == Long.MAX_VALUE) {
@@ -83,11 +95,32 @@ object UnreadDialogRetention {
             val delay = (earliest - now).coerceAtLeast(50L)
             val runnable = Runnable {
                 pendingExpireRunnable = null
-                notifyDialogsReload()
+                fireExpiredAndReload()
                 scheduleNextExpiration()
             }
             pendingExpireRunnable = runnable
             AndroidUtilities.runOnUIThread(runnable, delay)
+        }
+    }
+
+    private fun fireExpiredAndReload() {
+        val now = System.currentTimeMillis()
+        val accountsToReload = mutableSetOf<Int>()
+        for ((account, map) in expireAtByAccount) {
+            val it = map.entries.iterator()
+            var changed = false
+            while (it.hasNext()) {
+                if (it.next().value <= now) {
+                    it.remove()
+                    changed = true
+                }
+            }
+            if (changed) {
+                accountsToReload.add(account)
+            }
+        }
+        for (account in accountsToReload) {
+            notifyDialogsReload(account)
         }
     }
 
@@ -96,13 +129,14 @@ object UnreadDialogRetention {
         pendingExpireRunnable = null
     }
 
-    private fun notifyDialogsReload() {
-        for (account in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
-            if (!UserConfig.getInstance(account).isClientActivated) {
-                continue
-            }
-            NotificationCenter.getInstance(account)
-                .postNotificationName(NotificationCenter.dialogsNeedReload)
+    private fun notifyDialogsReload(account: Int) {
+        if (account < 0 || account >= UserConfig.MAX_ACCOUNT_COUNT) {
+            return
         }
+        if (!UserConfig.getInstance(account).isClientActivated) {
+            return
+        }
+        NotificationCenter.getInstance(account)
+            .postNotificationName(NotificationCenter.dialogsNeedReload)
     }
 }

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019-2025 qwq233 <qwq233@qwq2333.top>
+ * https://github.com/qwq233/Nullgram
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this software.
+ *  If not, see
+ * <https://www.gnu.org/licenses/>
+ */
+package xyz.nextalone.nnngram.utils
+
+import org.telegram.messenger.AndroidUtilities
+import org.telegram.messenger.NotificationCenter
+import org.telegram.messenger.UserConfig
+import xyz.nextalone.gen.Config
+import java.util.concurrent.ConcurrentHashMap
+
+object UnreadDialogRetention {
+
+    private val expireAtById = ConcurrentHashMap<Long, Long>()
+
+    private var pendingExpireRunnable: Runnable? = null
+
+    @JvmStatic
+    fun isEnabled(): Boolean = Config.getUnreadDialogRetention() > 0
+
+    @JvmStatic
+    fun getRetentionMillis(): Long = Config.getUnreadDialogRetention() * 1000L
+
+    @JvmStatic
+    fun onDialogOpened(dialogId: Long) {
+        val retentionMillis = getRetentionMillis()
+        if (retentionMillis <= 0) {
+            return
+        }
+        expireAtById[dialogId] = System.currentTimeMillis() + retentionMillis
+        scheduleNextExpiration()
+    }
+
+    @JvmStatic
+    fun shouldRetain(dialogId: Long): Boolean {
+        if (!isEnabled()) {
+            return false
+        }
+        val expireAt = expireAtById[dialogId] ?: return false
+        if (System.currentTimeMillis() >= expireAt) {
+            expireAtById.remove(dialogId)
+            return false
+        }
+        return true
+    }
+
+    @JvmStatic
+    fun clear() {
+        expireAtById.clear()
+        cancelPending()
+    }
+
+    private fun scheduleNextExpiration() {
+        AndroidUtilities.runOnUIThread {
+            cancelPending()
+            val now = System.currentTimeMillis()
+            var earliest = Long.MAX_VALUE
+            for ((id, expireAt) in expireAtById) {
+                if (expireAt <= now) {
+                    expireAtById.remove(id)
+                } else if (expireAt < earliest) {
+                    earliest = expireAt
+                }
+            }
+            if (earliest == Long.MAX_VALUE) {
+                return@runOnUIThread
+            }
+            val delay = (earliest - now).coerceAtLeast(50L)
+            val runnable = Runnable {
+                pendingExpireRunnable = null
+                notifyDialogsReload()
+                scheduleNextExpiration()
+            }
+            pendingExpireRunnable = runnable
+            AndroidUtilities.runOnUIThread(runnable, delay)
+        }
+    }
+
+    private fun cancelPending() {
+        pendingExpireRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
+        pendingExpireRunnable = null
+    }
+
+    private fun notifyDialogsReload() {
+        for (account in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
+            if (!UserConfig.getInstance(account).isClientActivated) {
+                continue
+            }
+            NotificationCenter.getInstance(account)
+                .postNotificationName(NotificationCenter.dialogsNeedReload)
+        }
+    }
+}

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -31,10 +31,10 @@ object UnreadDialogRetention {
     private var pendingExpireRunnable: Runnable? = null
 
     @JvmStatic
-    fun isEnabled(): Boolean = Config.getUnreadDialogRetention() > 0
+    fun isEnabled(): Boolean = Config.unreadDialogRetention > 0
 
     @JvmStatic
-    fun getRetentionMillis(): Long = Config.getUnreadDialogRetention() * 1000L
+    fun getRetentionMillis(): Long = Config.unreadDialogRetention * 1000L
 
     @JvmStatic
     fun onDialogOpened(account: Int, dialogId: Long) {

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nullgram.xml
@@ -363,6 +363,11 @@
     <string name="MergeMessage">合併訊息</string>
     <string name="filterZalgo">過濾 \"Zalgo\" 符號</string>
     <string name="ignoreFolderUnreadCount">忽略資料夾標籤上的未讀計數</string>
+    <string name="unreadDialogRetention">已讀會話在未讀資料夾中保留</string>
+    <string name="unreadDialogRetentionOff">關閉</string>
+    <string name="unreadDialogRetention5Min">5 分鐘</string>
+    <string name="unreadDialogRetention30Min">30 分鐘</string>
+    <string name="unreadDialogRetention2Hour">2 小時</string>
     <string name="customTitle">自定义标题</string>
     <string name="setCustomTitle">设置自定义标题</string>
     <string name="drawerList">側邊欄列表</string>

--- a/TMessagesProj/src/main/res/values-zh/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values-zh/strings_nullgram.xml
@@ -367,6 +367,11 @@
     <string name="MergeMessage">合并消息</string>
     <string name="filterZalgo">过滤「Zalgo」符号</string>
     <string name="ignoreFolderUnreadCount">忽略文件夹标签上的未读计数</string>
+    <string name="unreadDialogRetention">已读会话在未读文件夹中保留</string>
+    <string name="unreadDialogRetentionOff">关闭</string>
+    <string name="unreadDialogRetention5Min">5 分钟</string>
+    <string name="unreadDialogRetention30Min">30 分钟</string>
+    <string name="unreadDialogRetention2Hour">2 小时</string>
     <string name="customTitle">自定义标题</string>
     <string name="setCustomTitle">设置自定义标题</string>
     <string name="drawerList">侧边栏列表</string>

--- a/TMessagesProj/src/main/res/values/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values/strings_nullgram.xml
@@ -380,6 +380,11 @@
     <string name="MergeMessage">Merge message</string>
     <string name="filterZalgo">Filter \"Zalgo\" symbols</string>
     <string name="ignoreFolderUnreadCount">Ignore folder unread count</string>
+    <string name="unreadDialogRetention">Keep read chats in unread folder</string>
+    <string name="unreadDialogRetentionOff">Off</string>
+    <string name="unreadDialogRetention5Min">5 minutes</string>
+    <string name="unreadDialogRetention30Min">30 minutes</string>
+    <string name="unreadDialogRetention2Hour">2 hours</string>
     <string name="customTitle">Custom title</string>
     <string name="setCustomTitle">Set custom title</string>
     <string name="drawerList">Drawer list</string>


### PR DESCRIPTION
Adds a setting under General → unreadDialogRetention with options
Off / 5 min / 30 min / 2 hours. When enabled, opening an unread chat
in the "unread" filter does not immediately remove it; instead it stays
visible until the timeout elapses with no new activity, then disappears
on a scheduled reload.