### PR TITLE
refactor(dialogs): retain recently conversed chats in Unread via last_message_date

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -1305,7 +1305,7 @@ public class MessagesController extends BaseController implements NotificationCe
                 return false;
             }
             if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0 && messagesController.getDialogUnreadCount(d) == 0 && !d.unread_mark && d.unread_mentions_count == 0) {
-                if (!UnreadDialogRetention.isRecent(d)) {
+                if (!UnreadDialogRetention.isRecent(accountInstance.getCurrentAccount(), d)) {
                     return false;
                 }
             }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesController.java
@@ -1305,7 +1305,7 @@ public class MessagesController extends BaseController implements NotificationCe
                 return false;
             }
             if ((flags & DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0 && messagesController.getDialogUnreadCount(d) == 0 && !d.unread_mark && d.unread_mentions_count == 0) {
-                if (!UnreadDialogRetention.shouldRetain(accountInstance.getCurrentAccount(), dialogId)) {
+                if (!UnreadDialogRetention.isRecent(d)) {
                     return false;
                 }
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -286,7 +286,6 @@ import xyz.nextalone.nnngram.ui.SendOptionsMenuLayout;
 import xyz.nextalone.nnngram.utils.APKUtils;
 import xyz.nextalone.nnngram.utils.Defines;
 import xyz.nextalone.nnngram.utils.PrivacyUtils;
-import xyz.nextalone.nnngram.utils.UnreadDialogRetention;
 import xyz.nextalone.nnngram.utils.UpdateUtils;
 
 import me.vkryl.android.animator.BoolAnimator;
@@ -8045,15 +8044,6 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 }
             } else {
                 slowedReloadAfterDialogClick = true;
-                if (UnreadDialogRetention.isEnabled() && viewPages != null && viewPages.length > 0) {
-                    MessagesController.DialogFilter currentFilter = null;
-                    if (viewPages[0].dialogsType == 7 || viewPages[0].dialogsType == 8) {
-                        currentFilter = getMessagesController().selectedDialogFilter[viewPages[0].dialogsType == 8 ? 1 : 0];
-                    }
-                    if (currentFilter != null && (currentFilter.flags & MessagesController.DIALOG_FILTER_FLAG_EXCLUDE_READ) != 0) {
-                        UnreadDialogRetention.onDialogOpened(currentAccount, dialogId);
-                    }
-                }
                 if (getMessagesController().checkCanOpenChat(args, DialogsActivity.this)) {
                     TLRPC.Chat chat = getMessagesController().getChat(-dialogId);
                     TLRPC.Dialog dialog = getMessagesController().getDialog(dialogId);

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/activity/GeneralSettingActivity.java
@@ -290,7 +290,7 @@ public class GeneralSettingActivity extends BaseActivity {
             }
             PopupBuilder.show(arrayList, LocaleController.getString(R.string.unreadDialogRetention), currentIndex, getParentActivity(), view, i -> {
                 Config.setUnreadDialogRetention(types.get(i));
-                UnreadDialogRetention.clearAndReload();
+                UnreadDialogRetention.onSettingChanged();
                 listAdapter.notifyItemChanged(unreadDialogRetentionRow, PARTIAL);
             });
         } else if (position == autoDisableBuiltInProxyRow) {

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -19,24 +19,34 @@
 package xyz.nextalone.nnngram.utils
 
 import org.telegram.messenger.AndroidUtilities
+import org.telegram.messenger.ApplicationLoader
 import org.telegram.messenger.NotificationCenter
 import org.telegram.messenger.UserConfig
+import org.telegram.tgnet.ConnectionsManager
 import org.telegram.tgnet.TLRPC
 import xyz.nextalone.gen.Config
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Keeps "recently conversed" chats visible inside dialog filters that
  * exclude read messages. A dialog is considered recent if its
- * `last_message_date` is within the configured retention window.
+ * `last_message_date` is within the configured retention window
+ * (measured against the server-synced time, not device wall clock).
  *
- * When enabled, a periodic UI-thread runnable fires `dialogsNeedReload`
- * so that dialogs drop out of the list once their window elapses, even
- * in the absence of any other activity.
+ * Scheduling is event-driven: each `isRecent` hit reports its earliest
+ * expiration; a single pending UI-thread runnable fires exactly at that
+ * point so expired dialogs drop even without any other activity. The
+ * scheduler quiesces when no dialogs are retained and pauses work while
+ * the main interface is backgrounded.
  */
 object UnreadDialogRetention {
 
+    private val earliestExpireAt = AtomicLong(Long.MAX_VALUE)
+
+    @Volatile private var reconcileQueued = false
+    @Volatile private var pendingExpireAt = Long.MAX_VALUE
+
     private var pendingRunnable: Runnable? = null
-    @Volatile private var schedulerArmed = false
 
     @JvmStatic
     fun isEnabled(): Boolean = Config.unreadDialogRetention > 0
@@ -45,77 +55,70 @@ object UnreadDialogRetention {
     fun getRetentionMillis(): Long = Config.unreadDialogRetention * 1000L
 
     @JvmStatic
-    fun isRecent(dialog: TLRPC.Dialog?): Boolean {
+    fun isRecent(account: Int, dialog: TLRPC.Dialog?): Boolean {
         if (dialog == null) return false
         val retention = getRetentionMillis()
         if (retention <= 0) return false
         val lastSec = dialog.last_message_date
         if (lastSec <= 0) return false
-        val ageMillis = System.currentTimeMillis() - lastSec * 1000L
-        if (ageMillis !in 0..retention) return false
-        ensureSchedulerArmed()
+        val nowSec = ConnectionsManager.getInstance(account).currentTime
+        val ageSec = (nowSec - lastSec).toLong()
+        if (ageSec < 0) return true // clock skew: treat future timestamps as just now
+        val ageMillis = ageSec * 1000L
+        if (ageMillis > retention) return false
+        val expireAt = System.currentTimeMillis() + (retention - ageMillis)
+        atomicMin(earliestExpireAt, expireAt)
+        requestReconcile()
         return true
     }
 
-    private fun ensureSchedulerArmed() {
-        if (schedulerArmed) return
-        AndroidUtilities.runOnUIThread {
-            if (!schedulerArmed && isEnabled()) {
-                schedulerArmed = true
-                schedule()
-            }
-        }
-    }
-
     /**
-     * Re-schedule the periodic reload based on the current setting, and
-     * fire a reload immediately so that the new setting takes effect.
+     * Re-evaluate scheduling after a setting change: cancel any pending
+     * work and fire one reload so the new duration takes effect.
      */
     @JvmStatic
     fun onSettingChanged() {
-        cancelPending()
-        schedulerArmed = false
-        reloadAllAccounts()
-        if (isEnabled()) {
-            schedulerArmed = true
-            schedule()
+        AndroidUtilities.runOnUIThread {
+            cancelPending()
+            earliestExpireAt.set(Long.MAX_VALUE)
+            pendingExpireAt = Long.MAX_VALUE
+            reloadAllAccounts()
         }
     }
 
-    private fun schedule() {
-        cancelPending()
-        if (!isEnabled()) {
-            schedulerArmed = false
-            return
+    private fun requestReconcile() {
+        if (reconcileQueued) return
+        reconcileQueued = true
+        AndroidUtilities.runOnUIThread {
+            reconcileQueued = false
+            reconcile()
         }
-        val delay = pollIntervalMillis()
+    }
+
+    private fun reconcile() {
+        val candidate = earliestExpireAt.getAndSet(Long.MAX_VALUE)
+        if (candidate == Long.MAX_VALUE) return
+        if (!isEnabled()) return
+        if (ApplicationLoader.mainInterfacePaused) return
+        if (candidate >= pendingExpireAt) return
+        cancelPending()
+        pendingExpireAt = candidate
+        val delay = (candidate - System.currentTimeMillis()).coerceAtLeast(50L)
         val runnable = Runnable {
             pendingRunnable = null
-            if (!isEnabled()) {
-                schedulerArmed = false
-                return@Runnable
-            }
+            pendingExpireAt = Long.MAX_VALUE
+            if (!isEnabled()) return@Runnable
+            if (ApplicationLoader.mainInterfacePaused) return@Runnable
             reloadAllAccounts()
-            schedule()
         }
         pendingRunnable = runnable
         AndroidUtilities.runOnUIThread(runnable, delay)
     }
 
-    /**
-     * Poll interval: refresh often enough that expiring dialogs disappear
-     * in reasonable time, but sparsely for longer retention windows.
-     * retention / 10, clamped to [15s, 60s].
-     */
-    private fun pollIntervalMillis(): Long {
-        val retention = getRetentionMillis()
-        val scaled = retention / 10
-        return scaled.coerceIn(15_000L, 60_000L)
-    }
-
     private fun cancelPending() {
         pendingRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
         pendingRunnable = null
+        pendingExpireAt = Long.MAX_VALUE
     }
 
     private fun reloadAllAccounts() {
@@ -123,6 +126,14 @@ object UnreadDialogRetention {
             if (!UserConfig.getInstance(account).isClientActivated) continue
             NotificationCenter.getInstance(account)
                 .postNotificationName(NotificationCenter.dialogsNeedReload)
+        }
+    }
+
+    private fun atomicMin(ref: AtomicLong, candidate: Long) {
+        while (true) {
+            val cur = ref.get()
+            if (candidate >= cur) return
+            if (ref.compareAndSet(cur, candidate)) return
         }
     }
 }

--- a/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
+++ b/TMessagesProj/src/main/java/xyz/nextalone/nnngram/utils/UnreadDialogRetention.kt
@@ -21,14 +21,22 @@ package xyz.nextalone.nnngram.utils
 import org.telegram.messenger.AndroidUtilities
 import org.telegram.messenger.NotificationCenter
 import org.telegram.messenger.UserConfig
+import org.telegram.tgnet.TLRPC
 import xyz.nextalone.gen.Config
-import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Keeps "recently conversed" chats visible inside dialog filters that
+ * exclude read messages. A dialog is considered recent if its
+ * `last_message_date` is within the configured retention window.
+ *
+ * When enabled, a periodic UI-thread runnable fires `dialogsNeedReload`
+ * so that dialogs drop out of the list once their window elapses, even
+ * in the absence of any other activity.
+ */
 object UnreadDialogRetention {
 
-    private val expireAtByAccount = ConcurrentHashMap<Int, ConcurrentHashMap<Long, Long>>()
-
-    private var pendingExpireRunnable: Runnable? = null
+    private var pendingRunnable: Runnable? = null
+    @Volatile private var schedulerArmed = false
 
     @JvmStatic
     fun isEnabled(): Boolean = Config.unreadDialogRetention > 0
@@ -37,106 +45,84 @@ object UnreadDialogRetention {
     fun getRetentionMillis(): Long = Config.unreadDialogRetention * 1000L
 
     @JvmStatic
-    fun onDialogOpened(account: Int, dialogId: Long) {
-        val retentionMillis = getRetentionMillis()
-        if (retentionMillis <= 0) {
-            return
-        }
-        mapFor(account)[dialogId] = System.currentTimeMillis() + retentionMillis
-        scheduleNextExpiration()
-    }
-
-    @JvmStatic
-    fun shouldRetain(account: Int, dialogId: Long): Boolean {
-        if (!isEnabled()) {
-            return false
-        }
-        val map = expireAtByAccount[account] ?: return false
-        val expireAt = map[dialogId] ?: return false
-        if (System.currentTimeMillis() >= expireAt) {
-            map.remove(dialogId)
-            return false
-        }
+    fun isRecent(dialog: TLRPC.Dialog?): Boolean {
+        if (dialog == null) return false
+        val retention = getRetentionMillis()
+        if (retention <= 0) return false
+        val lastSec = dialog.last_message_date
+        if (lastSec <= 0) return false
+        val ageMillis = System.currentTimeMillis() - lastSec * 1000L
+        if (ageMillis !in 0..retention) return false
+        ensureSchedulerArmed()
         return true
     }
 
-    @JvmStatic
-    fun clearAndReload() {
-        val accounts = expireAtByAccount.keys.toList()
-        expireAtByAccount.clear()
-        cancelPending()
-        for (account in accounts) {
-            notifyDialogsReload(account)
-        }
-    }
-
-    private fun mapFor(account: Int): ConcurrentHashMap<Long, Long> =
-        expireAtByAccount.computeIfAbsent(account) { ConcurrentHashMap() }
-
-    private fun scheduleNextExpiration() {
+    private fun ensureSchedulerArmed() {
+        if (schedulerArmed) return
         AndroidUtilities.runOnUIThread {
-            cancelPending()
-            val now = System.currentTimeMillis()
-            var earliest = Long.MAX_VALUE
-            for ((_, map) in expireAtByAccount) {
-                val it = map.entries.iterator()
-                while (it.hasNext()) {
-                    val entry = it.next()
-                    if (entry.value <= now) {
-                        it.remove()
-                    } else if (entry.value < earliest) {
-                        earliest = entry.value
-                    }
-                }
+            if (!schedulerArmed && isEnabled()) {
+                schedulerArmed = true
+                schedule()
             }
-            if (earliest == Long.MAX_VALUE) {
-                return@runOnUIThread
-            }
-            val delay = (earliest - now).coerceAtLeast(50L)
-            val runnable = Runnable {
-                pendingExpireRunnable = null
-                fireExpiredAndReload()
-                scheduleNextExpiration()
-            }
-            pendingExpireRunnable = runnable
-            AndroidUtilities.runOnUIThread(runnable, delay)
         }
     }
 
-    private fun fireExpiredAndReload() {
-        val now = System.currentTimeMillis()
-        val accountsToReload = mutableSetOf<Int>()
-        for ((account, map) in expireAtByAccount) {
-            val it = map.entries.iterator()
-            var changed = false
-            while (it.hasNext()) {
-                if (it.next().value <= now) {
-                    it.remove()
-                    changed = true
-                }
-            }
-            if (changed) {
-                accountsToReload.add(account)
-            }
+    /**
+     * Re-schedule the periodic reload based on the current setting, and
+     * fire a reload immediately so that the new setting takes effect.
+     */
+    @JvmStatic
+    fun onSettingChanged() {
+        cancelPending()
+        schedulerArmed = false
+        reloadAllAccounts()
+        if (isEnabled()) {
+            schedulerArmed = true
+            schedule()
         }
-        for (account in accountsToReload) {
-            notifyDialogsReload(account)
+    }
+
+    private fun schedule() {
+        cancelPending()
+        if (!isEnabled()) {
+            schedulerArmed = false
+            return
         }
+        val delay = pollIntervalMillis()
+        val runnable = Runnable {
+            pendingRunnable = null
+            if (!isEnabled()) {
+                schedulerArmed = false
+                return@Runnable
+            }
+            reloadAllAccounts()
+            schedule()
+        }
+        pendingRunnable = runnable
+        AndroidUtilities.runOnUIThread(runnable, delay)
+    }
+
+    /**
+     * Poll interval: refresh often enough that expiring dialogs disappear
+     * in reasonable time, but sparsely for longer retention windows.
+     * retention / 10, clamped to [15s, 60s].
+     */
+    private fun pollIntervalMillis(): Long {
+        val retention = getRetentionMillis()
+        val scaled = retention / 10
+        return scaled.coerceIn(15_000L, 60_000L)
     }
 
     private fun cancelPending() {
-        pendingExpireRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
-        pendingExpireRunnable = null
+        pendingRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
+        pendingRunnable = null
     }
 
-    private fun notifyDialogsReload(account: Int) {
-        if (account < 0 || account >= UserConfig.MAX_ACCOUNT_COUNT) {
-            return
+    private fun reloadAllAccounts() {
+        for (account in 0 until UserConfig.MAX_ACCOUNT_COUNT) {
+            if (!UserConfig.getInstance(account).isClientActivated) continue
+            NotificationCenter.getInstance(account)
+                .postNotificationName(NotificationCenter.dialogsNeedReload)
         }
-        if (!UserConfig.getInstance(account).isClientActivated) {
-            return
-        }
-        NotificationCenter.getInstance(account)
-            .postNotificationName(NotificationCenter.dialogsNeedReload)
     }
 }

--- a/TMessagesProj/src/main/res/values-zh-rTW/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values-zh-rTW/strings_nullgram.xml
@@ -363,7 +363,7 @@
     <string name="MergeMessage">合併訊息</string>
     <string name="filterZalgo">過濾 \"Zalgo\" 符號</string>
     <string name="ignoreFolderUnreadCount">忽略資料夾標籤上的未讀計數</string>
-    <string name="unreadDialogRetention">已讀會話在未讀資料夾中保留</string>
+    <string name="unreadDialogRetention">在「未讀」中保留最近會話</string>
     <string name="unreadDialogRetentionOff">關閉</string>
     <string name="unreadDialogRetention5Min">5 分鐘</string>
     <string name="unreadDialogRetention30Min">30 分鐘</string>

--- a/TMessagesProj/src/main/res/values-zh/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values-zh/strings_nullgram.xml
@@ -367,7 +367,7 @@
     <string name="MergeMessage">合并消息</string>
     <string name="filterZalgo">过滤「Zalgo」符号</string>
     <string name="ignoreFolderUnreadCount">忽略文件夹标签上的未读计数</string>
-    <string name="unreadDialogRetention">已读会话在未读文件夹中保留</string>
+    <string name="unreadDialogRetention">在「未读」中保留最近会话</string>
     <string name="unreadDialogRetentionOff">关闭</string>
     <string name="unreadDialogRetention5Min">5 分钟</string>
     <string name="unreadDialogRetention30Min">30 分钟</string>

--- a/TMessagesProj/src/main/res/values/strings_nullgram.xml
+++ b/TMessagesProj/src/main/res/values/strings_nullgram.xml
@@ -380,7 +380,7 @@
     <string name="MergeMessage">Merge message</string>
     <string name="filterZalgo">Filter \"Zalgo\" symbols</string>
     <string name="ignoreFolderUnreadCount">Ignore folder unread count</string>
-    <string name="unreadDialogRetention">Keep read chats in unread folder</string>
+    <string name="unreadDialogRetention">Keep recent chats in Unread</string>
     <string name="unreadDialogRetentionOff">Off</string>
     <string name="unreadDialogRetention5Min">5 minutes</string>
     <string name="unreadDialogRetention30Min">30 minutes</string>


### PR DESCRIPTION
Reworks the retention semantics so any chat with messages (sent or
received) within the retention window stays visible in the Unread
filter — not just chats opened from the Unread tab.

- MessagesController.DialogFilter.includesDialog: when EXCLUDE_READ
  would drop a dialog, keep it if UnreadDialogRetention.isRecent(d).
- UnreadDialogRetention: drop per-account map and click tracking. Now
  purely reads dialog.last_message_date. A single self-scheduling
  UI runnable fires dialogsNeedReload every 15-60s (scaled to 1/10 of
  the retention window) so expired dialogs drop even without other
  activity. Scheduler arms itself lazily on first hit after app start.
- DialogsActivity: remove the click hook; no longer needed.
- GeneralSettingActivity: setting now calls onSettingChanged().
- Strings: rename title to "Keep recent chats in Unread" /
  "在「未读」中保留最近会话" / "在「未讀」中保留最近會話".