### PR TITLE
ci: truncate commit message before telegram upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,22 @@ jobs:
           chmod +x telegram-bot-api-binary
           ./telegram-bot-api-binary --api-id=21724 --api-hash=3e0cb5efcd52300aec5994fdfc5bdc16 --local 2>&1 > /dev/null &
           curl https://raw.githubusercontent.com/PreviousAlone/ActionScript/main/uploadCI.py -o uploadCI.py
-          # Legacy Telegram Markdown (used by uploadCI.py) fails with
-          # "can't parse entities" when the commit body contains backticks —
-          # they clash with the ``` fence the template wraps the message in.
-          # Strip them (and any CR) before passing to the uploader.
-          sanitized=$(printf '%s' "$COMMIT_MESSAGE" | tr -d '`\r')
+          # Normalise COMMIT_MESSAGE for the Telegram uploader:
+          # 1. Strip backticks — legacy Markdown parse_mode trips on
+          #    "can't parse entities" when the commit body contains them
+          #    because they collide with the ``` fence in the template.
+          # 2. Cap length — sendDocument caption limit is 1024 chars;
+          #    template + version adds ~120, so truncate the body to 800
+          #    to leave headroom and avoid HTTP 400.
+          sanitized=$(python3 <<'PY'
+          import os
+          s = os.environ["COMMIT_MESSAGE"].replace("`", "").replace("\r", "")
+          MAX = 800
+          if len(s) > MAX:
+              s = s[:MAX].rstrip() + "\n…(truncated)"
+          print(s)
+          PY
+          )
           COMMIT_MESSAGE="$sanitized" python uploadCI.py
         env:
             CHAT_ID: ${{ secrets.TELEGRAM_CHATID }}


### PR DESCRIPTION
sendDocument caption limit is 1024 chars. After backtick-stripping, long commit bodies still bust the limit and uploadCI.py fails with 400 Bad Request. Do both the strip and an 800-char cap in one Python step so the release notification survives verbose commits.

# Tittle Here
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
<!--- Describe your changes in detail here. -->

## Issues Fixed or Closed by This PR

## Check List

- [ ] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [ ] My code follows the code style of this project
- [ ] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
