### PR TITLE
style(MessagesSearchAdapter): show user's avatar in search results

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MessagesSearchAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/MessagesSearchAdapter.java
@@ -243,6 +243,7 @@ public class MessagesSearchAdapter extends RecyclerListView.SelectionAdapter imp
         if (holder.getItemViewType() == 0) {
             DialogCell cell = (DialogCell) holder.itemView;
             cell.useSeparator = true;
+            cell.useFromUserAsAvatar = true;
             MessageObject messageObject = (MessageObject) getItem(position);
             int date;
             long did;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -1691,7 +1691,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                             } else if (isSavedDialog && user != null && !user.self && message != null && message.isOutOwner() ||
                                 triedMessageName != null ||
                                 message != null && message.messageOwner != null && message.messageOwner.guestchat_via_from != null ||
-                                chat != null && chat.id > 0 && (fromChat == null || fromChat.id != chat.id) && (!ChatObject.isChannel(chat) || ChatObject.isMegagroup(chat)) && !ForumUtilities.isTopicCreateMessage(message) ||
+                                chat != null && chat.id > 0 && (fromChat == null || fromChat.id != chat.id) && (!ChatObject.isChannel(chat) || ChatObject.isMegagroup(chat)) && !ForumUtilities.isTopicCreateMessage(message) && !useFromUserAsAvatar ||
                                 user != null && user.id == UserObject.VERIFY && message != null && message.getForwardedFromId() != null
                             ) {
                                 messageNameString = AndroidUtilities.escape(triedMessageName != null ? triedMessageName : getMessageNameString());
@@ -2091,7 +2091,7 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                 nameString = getString(R.string.ArchivedChats);
             } else {
                 if (chat != null) {
-                    if (useFromUserAsAvatar) {
+                    if (useFromUserAsAvatar && chat.forum) {
                         if (topicIconInName == null) {
                             topicIconInName = new Drawable[1];
                         }
@@ -2100,6 +2100,8 @@ public class DialogCell extends BaseCell implements StoriesListPlaceProvider.Ava
                         if (nameString == null) {
                             nameString = "";
                         }
+                    } else if (useFromUserAsAvatar) {
+                        nameString = AndroidUtilities.escape(getMessageNameString());
                     } else if (isTopic) {
                         if (topicIconInName == null) {
                             topicIconInName = new Drawable[1];


### PR DESCRIPTION
# User avatar in chat search and no chat title duplicate
<!--- Provide a general summary of your changes in the title above. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->
Show other user avatar for in chat searches and doesn't show chat title in them (chat title was repeating in all results and they are obvious same)

## Description
<!--- Describe your changes in detail here. -->
When we search for messages in group chat, result list show group avatar and title in all results of other users. Which make it hard to identify who is user

In the code, DialogCell have useFromUserAsAvatar which if set to true will display user avatar not chat avatar.  It's set to true in MessageSearchAdapter (in chat search) so it shows avatar.

And in DialogCell logic, nameString is set to user's name if useFromUserAsAvatar is true but chat is not forum to move user's name on title row of cell. And pretty large if condition is changed to avoid adding user's name from message row of cell.

## Issues Fixed or Closed by This PR

## Check List

- [x] I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] My code follows the code style of this project
- [ ] I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
